### PR TITLE
fix building a `:latest` variant of images on push to main

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -45,9 +45,9 @@ jobs:
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   tags: |
-                      type=schedule,pattern=latest
                       type=ref,event=branch
                       type=ref,event=pr
+                      type=edge,branch=main
                   flavor: |
                       latest=auto
 

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -1,72 +1,78 @@
 name: Create and publish a Docker image
 
 on:
-  workflow_call:
-    inputs:
-      image_suffix:
-        required: true
-        description: Suffix of generated dockerimages' name
-        type: string
-      context:
-        required: true
-        description: Context, docker build is executed in
-        type: string
-      dockerfile:
-        required: true
-        description: Dockerfile location (relative to context)
-        type: string
+    workflow_call:
+        inputs:
+            image_suffix:
+                required: true
+                description: Suffix of generated dockerimages' name
+                type: string
+            context:
+                required: true
+                description: Context, docker build is executed in
+                type: string
+            dockerfile:
+                required: true
+                description: Dockerfile location (relative to context)
+                type: string
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/promptheus-${{ inputs.image_suffix }}
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository_owner }}/promptheus-${{ inputs.image_suffix }}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      packages: write
-      attestations: write
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+            packages: write
+            attestations: write
+        outputs:
+            tags: ${{ steps.meta.outputs.tags }}
+        steps:
+            - uses: actions/checkout@v4
+            - name: Log in to the Container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                  tags: |
+                      type=schedule,pattern=latest
+                      type=ref,event=branch
+                      type=ref,event=pr
+                  flavor: |
+                      latest=auto
 
-      - uses: docker/setup-buildx-action@v3
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          provenance: mode=max
-          sbom: true
-          context: ${{ inputs.context }}
-          push: true
-          file: "${{ inputs.context }}/${{ inputs.dockerfile }}"
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          build-args: |
-            GIT_COMMIT_SHA=${{ github.sha }}
-            GIT_COMMIT_MESSAGE="${github.event.head_commit.message//\n/}"
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-      - name: Attest
-        uses: actions/attest-build-provenance@v2
-        id: attest
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+            - uses: docker/setup-buildx-action@v3
+            - name: Build and push Docker image
+              id: push
+              uses: docker/build-push-action@v6
+              with:
+                  provenance: mode=max
+                  sbom: true
+                  context: ${{ inputs.context }}
+                  push: true
+                  file: "${{ inputs.context }}/${{ inputs.dockerfile }}"
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  annotations: ${{ steps.meta.outputs.annotations }}
+                  build-args: |
+                      GIT_COMMIT_SHA=${{ github.sha }}
+                      GIT_COMMIT_MESSAGE="${github.event.head_commit.message//\n/}"
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=min
+            - name: Attest
+              uses: actions/attest-build-provenance@v2
+              id: attest
+              with:
+                  subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                  subject-digest: ${{ steps.push.outputs.digest }}
+                  push-to-registry: true


### PR DESCRIPTION
Currently we don't publish images for these events.
Having the https://github.com/docker/metadata-action?tab=readme-ov-file#typeedge solves this, but retains the advantages of having docker images for the other events